### PR TITLE
Properly parse scoped package names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ typings/
 
 # Build output
 lib/
+
+# IDE files
+*.iml
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tbv",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Package verification for npm",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,8 @@ if (task === 'test') {
     verifier.on('progress', progress => verifier.printSteps(progress));
   }
 
-  const [packageName, version] = process.argv[3].split('@');
-  verifier.verify(packageName, version).then(success => {
+  const packageDescriptor = process.argv[3];
+  verifier.verify(packageDescriptor).then(success => {
     if (success) {
       console.log();
       console.log('\x1b[32mPASSED\x1b[0m');

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -26,7 +26,7 @@ export class Verifier extends Engine<VerifyProgress> {
       gitHead,
       shasum,
       tarballUri,
-    } = await this.registry(scope, packageName, version);
+    } = await this.registry(packageName, version, scope);
     if (this.hasFailed) return false;
 
     let cleanupDir: string;
@@ -64,9 +64,9 @@ export class Verifier extends Engine<VerifyProgress> {
   }
 
   private async registry(
-      scope: string | undefined,
       packageName: string,
       version: string,
+      scope?: string,
   ): Promise<{
     resolvedVersion?: string;
     repoUrl?: string;

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -79,7 +79,7 @@ export class Verifier extends Engine<VerifyProgress> {
     // Get package info
     let info: any;
     try {
-      let path = scope != undefined ? `${scope}/${packageName}` : `${packageName}`;
+      const path = scope != undefined ? `${scope}/${packageName}` : `${packageName}`;
       info = await this.get(`https://registry.npmjs.com/${path}`);
     } catch (err) {
       this.updateProgress(

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -12,7 +12,9 @@ export class Verifier extends Engine<VerifyProgress> {
   private nodeVersion = '';
   private npmVersion = '';
   async verify(packageDescriptor: string): Promise<boolean> {
-    const {scope, packageName, version} = this.splitPackageDescriptor(packageDescriptor)
+    const { scope, packageName, version } = this.splitPackageDescriptor(
+      packageDescriptor,
+    );
     this.progress = createProgress();
     this.hasFailed = false;
     this.hasPrinted = false;
@@ -51,22 +53,27 @@ export class Verifier extends Engine<VerifyProgress> {
     }
   }
 
-  private splitPackageDescriptor(packageDescriptor: string): {scope?: string, packageName: string, version: string} {
+  private splitPackageDescriptor(
+    packageDescriptor: string,
+  ): { scope?: string; packageName: string; version: string } {
     if (packageDescriptor.startsWith('@')) {
       const scopeSplit = packageDescriptor.split('/');
       const packageSplit = scopeSplit[1].split('@');
-      return {scope: scopeSplit[0], packageName: packageSplit[0], version: packageSplit[1]}
-    }
-    else {
-        let packageSplit = packageDescriptor.split('@');
-        return {packageName: packageSplit[0], version: packageSplit[1]};
+      return {
+        scope: scopeSplit[0],
+        packageName: packageSplit[0],
+        version: packageSplit[1],
+      };
+    } else {
+      let packageSplit = packageDescriptor.split('@');
+      return { packageName: packageSplit[0], version: packageSplit[1] };
     }
   }
 
   private async registry(
-      packageName: string,
-      version: string,
-      scope?: string,
+    packageName: string,
+    version: string,
+    scope?: string,
   ): Promise<{
     resolvedVersion?: string;
     repoUrl?: string;
@@ -79,7 +86,8 @@ export class Verifier extends Engine<VerifyProgress> {
     // Get package info
     let info: any;
     try {
-      const path = scope != undefined ? `${scope}/${packageName}` : `${packageName}`;
+      const path =
+        scope != undefined ? `${scope}/${packageName}` : `${packageName}`;
       info = await this.get(`https://registry.npmjs.com/${path}`);
     } catch (err) {
       this.updateProgress(


### PR DESCRIPTION
Since @ is used for scopes, as well as version specifiers, splitting on
it causes issues for scoped packages. Since the logic for splitting
became a little bit biggger, I moved it into the verifier.

I also squeezed in some .gitignore changes that would make me happy:)